### PR TITLE
3 titan overlap calc

### DIFF
--- a/src/simpletrack/frame_tracker.py
+++ b/src/simpletrack/frame_tracker.py
@@ -778,6 +778,12 @@ class FrameTracker:
         # Replace any zero sizes with 1 to avoid division by zero
         norm_sizes = np.where(norm_sizes == 0, 1, norm_sizes)
         overlap_normed = overlap_hist / norm_sizes
+
+        # Now, add to this the overlap normalised by the size of the current feature
+        current_feature_size = np.count_nonzero(current_feature_field == feature_id)
+        overlap_normed += overlap_hist / current_feature_size
+        # To restrict bounds to between 0 and 1, divide by 2
+        overlap_normed /= 2
         return overlap_normed
 
     def _get_overlap_sizes(

--- a/tests/test_frame_tracker.py
+++ b/tests/test_frame_tracker.py
@@ -371,11 +371,12 @@ def test_overlap_histogram(construct_test_fields):
     test_field, test_field2 = construct_test_fields[0:2]
 
     # Expect to find overlap of 2/3 for label 1
-    # And overlap = 12/16 = 0.75 for label 2
+    # And overlap = 0.65625 for label 2 (since the area of overlap is 15 pixels,
+    # and the total area of the feature in test_field2 is 16 pixels)
     # Label 0 is reserved for the background, which should be set to 0
     # But this is not tested here since this would throw an IDError
     ids = [1, 2]
-    expected_results = [2 / 3, 0.75]
+    expected_results = [2 / 3, 0.65625]
     for id, expected_result in zip(ids, expected_results):
         hist = FrameTracker().calculate_overlap_histogram(
             test_field, test_field2, feature_id=id
@@ -395,9 +396,10 @@ def test_overlap_histogram_with_nbhood(construct_test_fields):
 
     # Using a mask of radius 3 pixels around each feature, we now expect
     # to encompass all of the features with the same label in each field
-    # Therefore, for label 1 and 2, expect an overlap of 1 (full overlap)
+    # Therefore, for label 1, expect an overlap of 1 (full overlap)
+    # But label 2 is a different size in each field, so we expect an overlap of 14/16 = 0.875
     ids = [1, 2]
-    expected_results = [1, 1]
+    expected_results = [1, 0.875]
     for id, expected_result in zip(ids, expected_results):
         hist = FrameTracker().calculate_overlap_histogram(
             test_field, test_field2, feature_id=id, nbhood=3
@@ -425,8 +427,8 @@ def test_overlap_histogram_with_multiple_overlaps_and_different_labels(
         test_field4, test_field2, feature_id=2, nbhood=0
     )
 
-    # Expect overlap of 0.75 with label 3, and 1 with label 4
-    expected_hist = np.array([0, 0, 0, 0.75, 1])
+    # Expect overlap of 0.75 with label 3, and 0.5625 with label 4
+    expected_hist = np.array([0, 0, 0, 0.75, 0.5625])
     err_msg = f"Test failed: overlap ({hist}) not equal to expected overlap ({expected_hist})."
     np.testing.assert_array_equal(hist, expected_hist, err_msg)
 


### PR DESCRIPTION
Reverted overlap calculation in FrameTracker to the same strategy as v1.0, as this does a better job of accounting for differences in feature sizes between Frames. This gives more robust tracking and less chance of losing features. Minor change of normalising the overlap by 2 to keep the bounds between 0 and 1 (and with a corresponding reduction of the overlap thresholds by 2 to 0.3).